### PR TITLE
Batch requests

### DIFF
--- a/src/main/scala/sangria/gateway/http/GatewayServer.scala
+++ b/src/main/scala/sangria/gateway/http/GatewayServer.scala
@@ -26,7 +26,7 @@ class GatewayServer extends Logging {
   val client = new PlayHttpClient(new StandaloneAhcWSClient(new DefaultAsyncHttpClient))
 
   val directiveProviders = Map(
-    "http" → new HttpDirectiveProvider(client),
+    "http" → new HttpDirectiveProvider,
     "graphql" → new GraphQLDirectiveProvider,
     "faker" → new FakerDirectiveProvider,
     "basic" → new BasicDirectiveProvider)
@@ -43,7 +43,7 @@ class GatewayServer extends Logging {
 
       schemaProvider.schemaInfo // trigger initial schema load at startup
 
-      val routing = new GraphQLRouting(config, schemaProvider)
+      val routing = new GraphQLRouting(config, schemaProvider, new RequestResolver(client))
 
       Http().bindAndHandle(routing.route, config.bindHost, config.port).andThen {
         case Success(_) ⇒

--- a/src/main/scala/sangria/gateway/schema/materializer/directive/HttpDirectiveProvider.scala
+++ b/src/main/scala/sangria/gateway/schema/materializer/directive/HttpDirectiveProvider.scala
@@ -1,6 +1,7 @@
 package sangria.gateway.schema.materializer.directive
 
 import io.circe.Json
+import sangria.execution.deferred.{Deferred, DeferredResolver}
 import sangria.gateway.http.client.HttpClient
 import sangria.gateway.json.CirceJsonPath
 import sangria.gateway.schema.materializer.GatewayContext
@@ -8,43 +9,81 @@ import sangria.gateway.schema.materializer.GatewayContext.{convertArgs, namedTyp
 import sangria.schema.ResolverBasedAstSchemaBuilder.extractValue
 import sangria.schema._
 import sangria.marshalling.circe._
+import sangria.schema.InputObjectType.DefaultInput
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class HttpDirectiveProvider(client: HttpClient)(implicit ec: ExecutionContext) extends DirectiveProvider {
+class HttpDirectiveProvider extends DirectiveProvider {
   import HttpDirectiveProvider._
 
   def resolvers(ctx: GatewayContext) = Seq(
     DirectiveResolver(Dirs.HttpGet,
       complexity = Some(_ ⇒ (_, _, _) ⇒ 1000.0),
-      resolve = c ⇒ c.withArgs(Args.Url, Args.Headers, Args.QueryParams, Args.ForAll) { (rawUrl, rawHeaders, rawQueryParams, forAll) ⇒
-        val args = Some(convertArgs(c.ctx.args, c.ctx.astFields.head))
+      resolve = c ⇒ {
+        val json = c.ctx.value match {
+          case j: Json => j
+          case _ => Json.Null
+        }
+        RequestDescription(
+          c.ctx,
+          c.arg(Args.Url),
+          c.arg(Args.Headers),
+          c.arg(Args.QueryParams),
+          c.arg(Args.ForAll),
+          c.arg(Args.BatchUrl),
+          c.arg(Args.IdFieldInBatchResponse),
+          json
+        )
+      }
+    )
+  )
+}
+
+case class RequestDescription(
+  context: Context[GatewayContext, _],
+  rawUrl: String,
+  rawHeaders: Option[Seq[DefaultInput]],
+  rawQueryParams: Option[Seq[DefaultInput]],
+  forAll: Option[String],
+  batchUrl: Option[String],
+  idFieldInBatchResponse: Option[String],
+  id: Json
+) extends Deferred[Json]
+
+class RequestResolver(client: HttpClient) extends DeferredResolver[GatewayContext] {
+  def resolve(deferred: Vector[Deferred[Any]], gwCtx: GatewayContext, queryState: Any)(implicit ec: ExecutionContext): Vector[Future[Any]] = {
+    deferred.map {
+      case rd: RequestDescription =>
+        import rd._
+        val args = Some(convertArgs(context.args, context.astFields.head))
 
         def extractMap(in: Option[scala.Seq[InputObjectType.DefaultInput]], elem: Json) =
-          rawHeaders.map(_.map(h ⇒ h("name").asInstanceOf[String] → c.ctx.ctx.fillPlaceholders(c.ctx, h("value").asInstanceOf[String], args, elem))).getOrElse(Nil)
+          rawHeaders.map(_.map(h ⇒ h("name").asInstanceOf[String] → gwCtx.fillPlaceholders(context, h("value").asInstanceOf[String], args, elem))).getOrElse(Nil)
 
-        def makeRequest(tpe: OutputType[_], c: Context[GatewayContext, _], args: Option[Json], elem: Json = Json.Null) = {
-          val url = c.ctx.fillPlaceholders(c, rawUrl, args, elem)
+        def makeRequest(tpe: OutputType[_], c: Context[GatewayContext, _], args: Option[Json], elem: Json = Json.Null): Future[Json] = {
+          val url = gwCtx.fillPlaceholders(c, rawUrl, args, elem)
           val headers = extractMap(rawHeaders, elem)
           val query = extractMap(rawQueryParams, elem)
 
           client.request(HttpClient.Method.Get, url, query, headers).flatMap(GatewayContext.parseJson)
         }
 
+        val fieldType: OutputType[_] = context.field.fieldType
         forAll match {
-          case Some(elem) ⇒
-            CirceJsonPath.query(c.ctx.value.asInstanceOf[Json], elem) match {
+          case Some(jsonPath) ⇒
+            CirceJsonPath.query(id, jsonPath) match {
               case json: Json if json.isArray ⇒
-                Future.sequence(json.asArray.get.map(e ⇒ makeRequest(namedType(c.ctx.field.fieldType), c.ctx, args, e))) map { v ⇒
-                  extractValue(c.ctx.field.fieldType, Some(Json.arr(v.asInstanceOf[Seq[Json]]: _*)))
+                Future.sequence(json.asArray.get.map(e ⇒ makeRequest(namedType(fieldType), context, args, e))) map { v ⇒
+                  extractValue(fieldType, Some(Json.arr(v.asInstanceOf[Seq[Json]]: _*)))
                 }
               case e ⇒
-                makeRequest(c.ctx.field.fieldType, c.ctx, args, e)
+                makeRequest(fieldType, context, args, e)
             }
           case None ⇒
-            makeRequest(c.ctx.field.fieldType, c.ctx, args)
+            makeRequest(fieldType, context, args)
         }
-      }))
+    }
+  }
 }
 
 object HttpDirectiveProvider {
@@ -61,11 +100,13 @@ object HttpDirectiveProvider {
     val Headers = Argument("headers", OptionInputType(ListInputType(HeaderType)))
     val QueryParams = Argument("query", OptionInputType(ListInputType(QueryParamType)))
     val ForAll = Argument("forAll", OptionInputType(StringType))
+    val BatchUrl = Argument("batchUrl", OptionInputType(StringType))
+    val IdFieldInBatchResponse = Argument("idFieldInBatchResponse", OptionInputType(StringType))
   }
 
   object Dirs {
     val HttpGet = Directive("httpGet",
-      arguments = Args.Url :: Args.Headers :: Args.QueryParams :: Args.ForAll :: Nil,
+      arguments = Args.Url :: Args.Headers :: Args.QueryParams :: Args.ForAll :: Args.BatchUrl :: Args.IdFieldInBatchResponse :: Nil,
       locations = Set(DirectiveLocation.FieldDefinition))
   }
 }


### PR DESCRIPTION
Ok, this is ugly as hell, but maybe a starting point for discussion.
I've changed the logic of `HttpDirectiveProvider` to return a `RequestDescription <: Deferred[Json]` and created a `RequestResolver <: DeferredResolver[GatewayContext]` which performs the actual logic.
In principle one could now go ahead and transform a `Vector[RequestDescription]` into batch requests, but there's too many things that feel just awfully wrong:

1. `RequestDescription` needs to store the entire `Context[GatewayContext, _]` so that the `RequestResolver` can execute its logic. It would be much nicer if it would suffice to have a `GatewayContext` which would be the `Ctx` of `RequestResolver` anyway, but `Context[GatewayContext, _]` is needed for `fillPlaceholders`.
2. I don't know if it's ok to just [replace the  `schemaInfo.deferredResolver`](https://github.com/OlegIlyenko/graphql-gateway/compare/master...nightscape:batch_requests?expand=1#diff-a2e90eb5a22e4a1a5c6d1cdec8660c70L142). It seems that it's an empty resolver by default.
3. It would be much nicer to use the high-level `Fetcher` API. The point where I got stuck with this is that a `Fetcher` needs a `HasId[Res, Id]`, so `Id` can't be something complicated like my `RequestDescription`. But if I make `Id` something simple like a `Json` object, I wouldn't know how to get all the other required things into the `Fetcher`.

If you have any ideas how to make this nicer I'd be very thankful :smiley: 